### PR TITLE
Added support for setting host and port for swampdragon server

### DIFF
--- a/swampdragon/swampdragon_server.py
+++ b/swampdragon/swampdragon_server.py
@@ -13,8 +13,8 @@ def run_server():
         django.setup()
 
     args = sys.argv
-    HOST = '127.0.0.1'
-    PORT = 9999
+    HOST = getattr(settings, 'SWAMP_DRAGON_HOST', '127.0.0.1')
+    PORT = getattr(settings, 'SWAMP_DRAGON_PORT', 9999)
 
     if len(args) > 1:
         host_port = args[1]


### PR DESCRIPTION
It's useful to be able to set the host and port for the swampdragon server, so I added settings for those things. 
