### PR TITLE
Fix behaviour of $dragon.onReady

### DIFF
--- a/swampdragon/static/swampdragon/js/angular/services.js
+++ b/swampdragon/static/swampdragon/js/angular/services.js
@@ -1,7 +1,7 @@
 var SwampDragonServices = angular.module('SwampDragonServices', []);
 
 
-SwampDragonServices.factory('$dragon', ['$q', function ($q) {
+SwampDragonServices.factory('$dragon', ['$q', '$timeout', function ($q, $timeout) {
     var endpoint = window.swampdragon_settings.endpoint;
 
     var dragon =  {
@@ -13,9 +13,13 @@ SwampDragonServices.factory('$dragon', ['$q', function ($q) {
 
         onReady: function(fn) {
             if(this.isReady()){
-                fn();
+                $timeout(function(){
+                    fn();
+                }, 0);
             }
-            this._readyCallbacks.push(fn);
+            else{
+                this._readyCallbacks.push(fn);
+            }
         },
 
         onLoginRequired: function(fn) {

--- a/swampdragon/static/swampdragon/js/angular/services.js
+++ b/swampdragon/static/swampdragon/js/angular/services.js
@@ -12,6 +12,9 @@ SwampDragonServices.factory('$dragon', ['$q', function ($q) {
         _heartbeatCallbacks: [],
 
         onReady: function(fn) {
+            if(this.isReady()){
+                fn();
+            }
             this._readyCallbacks.push(fn);
         },
 
@@ -64,7 +67,9 @@ SwampDragonServices.factory('$dragon', ['$q', function ($q) {
         },
 
         isReady: function() {
-            return swampDragon.isReady;
+            if(typeof this.swampDragon === 'undefined')
+                return false;
+            return this.swampDragon.isReady;
         },
 
         on: function (eventName, callback) {


### PR DESCRIPTION
I had the problem that certain callbacks which had been registered with $dragon.onReady were almost never executed. It turned out that the $dragon service registers the callbacks and only calls them the moment swampdragon gets ready. So if a callback is registered after swampdragon has already been initialized it will never be executed. I thought it would make more sense to execute these callbacks directly if swampdragon is already initialized instead of omitting them.