### PR TITLE
fixed missing channel name when publishing delete message 

### DIFF
--- a/swampdragon/pubsub_providers/model_publisher.py
+++ b/swampdragon/pubsub_providers/model_publisher.py
@@ -30,4 +30,5 @@ def publish_model(model_instance, serializer, action, changed_fields=None):
         publish_data = {'data': {'id': model_instance.pk}}
         publish_data['action'] = PUBACTIONS.deleted
         for channel in remove_from_channels:
+            publish_data['channel'] = channel
             publisher.publish(channel, publish_data)


### PR DESCRIPTION
If I have understood it correctly, an autopublished model instanced that does not pass the filtering is sent as a 'delete message', but it misses the channel name. Probably also resolves #50.