### PR TITLE
Fix import error of SimpleCookie for Python 2.7

### DIFF
--- a/tests/test_same_origin.py
+++ b/tests/test_same_origin.py
@@ -1,4 +1,8 @@
-from http.cookies import SimpleCookie
+try:
+    from http.cookies import SimpleCookie
+except ImportError:
+    from Cookie import SimpleCookie
+
 from django.conf import settings
 from sockjs.tornado.session import ConnectionInfo
 from swampdragon.connections.sockjs_connection import SubscriberConnection


### PR DESCRIPTION
`Cookie` was renamed to `http.cookies` in Python 3