### PR TITLE
Add import path for publish_data in the documentation

### DIFF
--- a/docs/publish-data.md
+++ b/docs/publish-data.md
@@ -7,6 +7,8 @@ This can be achived by using ```publish_data```.
 
 A celery task could look something like this:
     
+    from swampdragon.pubsub_providers.data_publisher import publish_data
+    
     @task()
     def my_task():
         data = get_some_data()  # get_some_data would return a dictionary


### PR DESCRIPTION
Title says it all. Publishing data documentation is missing the import. http://swampdragon.net/documentation/publishing-data/