### PR TITLE
Django 1.8 related model changed to related.related_model

### DIFF
--- a/swampdragon/serializers/object_map.py
+++ b/swampdragon/serializers/object_map.py
@@ -59,7 +59,12 @@ def get_object_map(serializer, ignore_serializer_pairs=None):
                 attname = field_type.field.rel.name
 
         if is_o2o:
-            model = field_type.related.model
+            # Django 1.8:
+            # the related.model is related.related_model in Django 1.8
+            if hasattr(field_type.related, 'related_model'):
+                model = field_type.related.related_model
+            else:
+                model = field_type.related.model
             is_collection = False
             attname = field_type.related.field.name
 
@@ -69,7 +74,12 @@ def get_object_map(serializer, ignore_serializer_pairs=None):
             attname = field_type.related.field.name
 
         if is_m2m:
-            model = field_type.related.model
+            # Django 1.8:
+            # the related.model is related.related_model in Django 1.8
+            if hasattr(field_type.related, 'related_model'):
+                model = field_type.related.related_model
+            else:
+                model = field_type.related.model
             is_collection = True
             attname = field_type.related.field.name
 

--- a/tests/test_object_map.py
+++ b/tests/test_object_map.py
@@ -74,15 +74,28 @@ class TestObjectMap(DragonTestCase):
         om = FooSerializerOM.get_object_map()
         for m in om:
             self.assertFalse(m['is_collection'])
+            if m['parent_type'] == 'fooone2oneom':
+                self.assertEqual(m['child_type'], 'barone2oneom')
+            else:
+                self.assertEqual(m['child_type'], 'fooone2oneom')
 
     def test_get_object_map_for_reverse_one2one(self):
         om = BarSerializerOM.get_object_map()
         for m in om:
             self.assertFalse(m['is_collection'])
+            if m['parent_type'] == 'fooone2oneom':
+                self.assertEqual(m['child_type'], 'barone2oneom')
+            else:
+                self.assertEqual(m['child_type'], 'fooone2oneom')
 
     def test_get_object_map_for_fk(self):
         om = ChildSerializerOM.get_object_map()
         self.assertEqual(len(om), 2)
+        for m in om:
+            if m['parent_type'] == 'parentmodel':
+                self.assertEqual(m['child_type'], 'childmodel')
+            else:
+                self.assertEqual(m['child_type'], 'parentmodel')
 
     def test_get_object_map_for_reverse_fk(self):
         om = ParentSerializerOM.get_object_map()
@@ -91,3 +104,8 @@ class TestObjectMap(DragonTestCase):
     def test_get_object_map_form_m2m(self):
         om = FooM2MSerializer.get_object_map()
         self.assertEqual(len(om), 2)
+        for m in om:
+            if m['parent_type'] == 'foom2mom':
+                self.assertEqual(m['child_type'], 'barm2mom')
+            else:
+                self.assertEqual(m['child_type'], 'foom2mom')


### PR DESCRIPTION
Turns out there were more fixes needed, i only saw the reverse_fk because i was only using that one in my project.
 + added more test for the object map