### PR TITLE
use django.apps instead of django.db.models.loading (which will be removed in django 1.9)

### DIFF
--- a/swampdragon/model_tools.py
+++ b/swampdragon/model_tools.py
@@ -1,5 +1,8 @@
-from django.db.models.loading import get_model as get_django_model
-
+try:
+    from django.apps import apps
+    get_django_model = apps.get_model
+except ImportError:
+    from django.db.models.loading import get_model as get_django_model
 
 def get_property(obj, field):
     field = field.replace('__', '.')

--- a/swampdragon/swampdragon_server.py
+++ b/swampdragon/swampdragon_server.py
@@ -1,6 +1,9 @@
 import django
 from django.conf import settings
-from django.utils.importlib import import_module
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
 from tornado import web, ioloop
 from sockjs.tornado import SockJSRouter
 from swampdragon import discover_routes, load_field_deserializers, VERSION


### PR DESCRIPTION
I made this fix to remove this warning in django 1.8:

site-packages/swampdragon/model_tools.py:1: RemovedInDjango19Warning: The utilities in django.db.models.loading are deprecated in favor of the new application loading system.
  from django.db.models.loading import get_model as get_django_model