### PR TITLE
update runsd command to be compliant with django 1.8

### DIFF
--- a/swampdragon/management/commands/runsd.py
+++ b/swampdragon/management/commands/runsd.py
@@ -4,8 +4,19 @@ from swampdragon.swampdragon_server import run_server
 
 
 class Command(BaseCommand):
+    args = '<host_port>'
+    
     def handle(self, *args, **options):
         host_port = None
         if args:
             host_port = args[0]
         run_server(host_port=host_port)
+        
+    """
+    # This is the preferred way to implement positional arguments in Django 1.8, but breaks pre 1.8
+    def add_arguments(self, parser):
+        parser.add_argument('host_port', nargs='?', default=None, type=str)
+
+    def handle(self, *args, **options):
+        run_server(host_port=options['host_port'])
+    """


### PR DESCRIPTION
Management commands that only accept positional requirements need to have the args variable defined.
https://docs.djangoproject.com/en/1.8/releases/1.8/#management-commands-that-only-accept-positional-arguments