### PR TITLE
Django 1.8 warning: Replace remaining use of django.db.models.loading

### DIFF
--- a/swampdragon/__init__.py
+++ b/swampdragon/__init__.py
@@ -8,7 +8,11 @@ def discover_routes():
     Returns urls for each route handler
     """
     from django.conf import settings
-    from django.utils.importlib import import_module
+    try:
+        from importlib import import_module
+    except ImportError:
+        from django.utils.importlib import import_module
+
     imported_routers = []
     urls = []
     for app in settings.INSTALLED_APPS:
@@ -27,7 +31,11 @@ def discover_routes():
 
 def load_field_deserializers():
     from django.conf import settings
-    from django.utils.importlib import import_module
+    try:
+        from importlib import import_module
+    except ImportError:
+        from django.utils.importlib import import_module
+
     imported_deserializers = []
     for app in settings.INSTALLED_APPS:
         try:

--- a/swampdragon/sessions/sessions.py
+++ b/swampdragon/sessions/sessions.py
@@ -1,6 +1,9 @@
 from .redis_session_store import RedisSessionStore
 from django.conf import settings
-from django.utils.importlib import import_module
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
 
 
 session_store = None

--- a/swampdragon/testing/dragon_testcase.py
+++ b/swampdragon/testing/dragon_testcase.py
@@ -5,7 +5,10 @@ from swampdragon.pubsub_providers.subscriber_factory import get_subscription_pro
 from swampdragon.connections.mock_connection import TestConnection
 from django.test import TestCase
 from django.conf import settings
-from django.utils.importlib import import_module
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
 from sockjs.tornado import SockJSRouter
 from tornado import web
 from swampdragon.settings_provider import SettingsHandler


### PR DESCRIPTION
Use importlib instead of django.db.models.loading - fix remaining occurrences missed by https://github.com/jonashagstedt/swampdragon/pull/97