### PR TITLE
Added SWAMP_DRAGON_PUBLISH_ENABLED setting

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -57,6 +57,9 @@ This setting will override the default `localhost` host
 
 This setting will override the default `9999` port
 
+### ```SWAMP_DRAGON_PUBLISH_ENABLED```
+
+If set to ```False``` it turns the publishing of changes off. Default value is ```True```.
 
 ## JavaScript settings (settings exposed to clients via JavaScript)
 

--- a/swampdragon/models.py
+++ b/swampdragon/models.py
@@ -1,4 +1,5 @@
 from django.db.models import ForeignKey
+from django.conf import settings
 from .pubsub_providers.base_provider import PUBACTIONS
 from .model_tools import get_property
 from .pubsub_providers.model_publisher import publish_model
@@ -77,7 +78,10 @@ class SelfPublishModel(object):
         return self._serializer.serialize()
 
     def _publish(self, action, changed_fields=None):
-        publish_model(self, self._serializer, action, changed_fields)
+        PUBLISH_ENABLED = getattr(settings, 'SWAMP_DRAGON_PUBLISH_ENABLED', True)
+
+        if PUBLISH_ENABLED:
+            publish_model(self, self._serializer, action, changed_fields)
 
     def save(self, *args, **kwargs):
         if not self.pk:


### PR DESCRIPTION
This setting comes in handy if anyone is handling multiple deployments and want's to disable Swamp Dragon. 

To explain a bit more - this is our usecase:
We're having same codebase for multiple deployments. Some servers are used for local replicas and should not provide websockets - redis is not present on those machines. With this pull request developers will be able to turn off the socket support when needed by simply editing the settings. 

