### PR TITLE
Support serialization of models with fields named 'data'.

### DIFF
--- a/swampdragon/serializers/model_serializer.py
+++ b/swampdragon/serializers/model_serializer.py
@@ -46,7 +46,7 @@ class ModelSerializer(Serializer):
             raise Exception('data needs to be a dictionary')
         self.opts = ModelSerializerMeta(self.Meta)
         self._instance = instance
-        self.data = data
+        self._data = data
         self.initial = initial or {}
         self.base_fields = self._get_base_fields()
         self.m2m_fields = self._get_m2m_fields()
@@ -81,11 +81,11 @@ class ModelSerializer(Serializer):
             setattr(self.instance, key, val)
 
         # Deserialize base fields
-        for key, val in self.data.items():
+        for key, val in self._data.items():
             if key not in self.opts.update_fields or key not in self.base_fields:
                 continue
             try:
-                self.validate_field(key, val, self.data)
+                self.validate_field(key, val, self._data)
                 self._deserialize_field(key, val)
             except ModelValidationError as err:
                 self.errors.update(err.get_error_dict())
@@ -106,13 +106,13 @@ class ModelSerializer(Serializer):
         self.instance.save()
 
         # Serialize related fields
-        for key, val in self.data.items():
+        for key, val in self._data.items():
             if key not in self.related_fields:
                 continue
             self._deserialize_related(key, val)
 
         # Serialize m2m fields
-        for key, val in self.data.items():
+        for key, val in self._data.items():
             if key not in self.m2m_fields:
                 continue
             self._deserialize_related(key, val, save_instance=True)

--- a/tests/test_model_serializer_deserialize.py
+++ b/tests/test_model_serializer_deserialize.py
@@ -5,6 +5,30 @@ from datetime import datetime
 from django.db import models
 
 
+# to make sure none of the ModelSerializer variables are clobbering the data
+MODEL_KEYWORDS = ('data', )
+# TODO: support the rest of these field names
+# MODEL_KEYWORDS = ('data', 'opts', 'initial', 'base_fields', 'm2m_fields', 'related_fields', 'errors')
+
+
+class KeywordModel(SDModel):
+    data = models.TextField()
+    # TODO: support the rest of these field names
+    # opts = models.TextField()
+    # initial = models.TextField()
+    # base_fields = models.TextField()
+    # m2m_fields = models.TextField()
+    # related_fields = models.TextField()
+    # errors = models.TextField()
+
+
+class KeywordModelSerializer(ModelSerializer):
+    class Meta:
+        model = KeywordModel
+        publish_fields = MODEL_KEYWORDS
+        update_fields = MODEL_KEYWORDS
+
+
 class DateModel(SDModel):
     date = models.DateTimeField()
 
@@ -47,3 +71,10 @@ class TestModelSerializer(DragonTestCase):
         serializer = DateModelSerializer(data)
         object = serializer.save()
         self.assertEqual(object.date, date)
+
+    def test_deserialize_keyword_field(self):
+        data = dict(zip(MODEL_KEYWORDS, MODEL_KEYWORDS))
+        serializer = KeywordModelSerializer(data)
+        object = serializer.save()
+        for attr in MODEL_KEYWORDS:
+            self.assertEqual(getattr(object, attr), attr)


### PR DESCRIPTION
I threw in some test code, but since this only takes care of 'data'
field there are TODOs to support fields by other names that
ModelSerializer currently clobbers.