### PR TITLE
Keep original stacktrace on SubscriberConnection.on_message exceptions.

### DIFF
--- a/swampdragon/connections/sockjs_connection.py
+++ b/swampdragon/connections/sockjs_connection.py
@@ -85,11 +85,9 @@ class SubscriberConnection(ConnectionMixin, SockJSConnection):
                 return
             handler = route_handler.get_route_handler(data['route'])
             handler(self).handle(data)
-        except Exception as e:
-            if settings.DEBUG:
-                print(e)
+        except Exception:
             self.abort_connection()
-            raise e
+            raise
 
     def abort_connection(self):
         self.close(code=3001, message='Connection aborted')


### PR DESCRIPTION
Removed the odd print statement since the exception already gets logged
further up the stack.

If it's really needed for some reason it would make more sense to use something like `logging.debug(e, exc_info=1)`.