### PR TITLE
Use importlib.

### DIFF
--- a/swampdragon/__init__.py
+++ b/swampdragon/__init__.py
@@ -8,7 +8,7 @@ def discover_routes():
     Returns urls for each route handler
     """
     from django.conf import settings
-    from django.utils.importlib import import_module
+    from importlib import import_module
     imported_routers = []
     urls = []
     for app in settings.INSTALLED_APPS:
@@ -27,7 +27,7 @@ def discover_routes():
 
 def load_field_deserializers():
     from django.conf import settings
-    from django.utils.importlib import import_module
+    from importlib import import_module
     imported_deserializers = []
     for app in settings.INSTALLED_APPS:
         try:

--- a/swampdragon/sessions/sessions.py
+++ b/swampdragon/sessions/sessions.py
@@ -1,6 +1,6 @@
 from .redis_session_store import RedisSessionStore
 from django.conf import settings
-from django.utils.importlib import import_module
+from importlib import import_module
 
 
 session_store = None

--- a/swampdragon/swampdragon_server.py
+++ b/swampdragon/swampdragon_server.py
@@ -1,9 +1,6 @@
 import django
 from django.conf import settings
-try:
-    from importlib import import_module
-except ImportError:
-    from django.utils.importlib import import_module
+from importlib import import_module
 from tornado import web, ioloop
 from sockjs.tornado import SockJSRouter
 from swampdragon import discover_routes, load_field_deserializers, VERSION

--- a/swampdragon/testing/dragon_testcase.py
+++ b/swampdragon/testing/dragon_testcase.py
@@ -6,7 +6,7 @@ from swampdragon.pubsub_providers.subscriber_factory import get_subscription_pro
 from swampdragon.connections.mock_connection import TestConnection
 from django.test import TestCase
 from django.conf import settings
-from django.utils.importlib import import_module
+from importlib import import_module
 from sockjs.tornado import SockJSRouter
 from tornado import web
 from swampdragon.settings_provider import SettingsHandler


### PR DESCRIPTION
django.utils.importlib will be removed from Django in 1.9 and is only
needed for python versions before 2.7.