### PR TITLE
Add optional Redis DB password parameter to settings

### DIFF
--- a/swampdragon/pubsub_providers/redis_publisher.py
+++ b/swampdragon/pubsub_providers/redis_publisher.py
@@ -1,6 +1,6 @@
 import json
 import redis
-from .redis_settings import get_redis_host, get_redis_port, get_redis_db
+from .redis_settings import get_redis_host, get_redis_port, get_redis_db, get_redis_password
 
 _redis_cli = None
 
@@ -11,7 +11,8 @@ def get_redis_cli():
         _redis_cli = redis.StrictRedis(
             host=get_redis_host(),
             port=get_redis_port(),
-            db=get_redis_db()
+            db=get_redis_db(),
+            password=get_redis_password()
         )
     return _redis_cli
 

--- a/swampdragon/pubsub_providers/redis_settings.py
+++ b/swampdragon/pubsub_providers/redis_settings.py
@@ -3,6 +3,7 @@ from django.conf import settings
 redis_host = None
 redis_port = None
 redis_db = None
+redis_password = None
 
 
 def get_redis_host():
@@ -24,3 +25,10 @@ def get_redis_db():
     if not redis_db:
         redis_db = getattr(settings, 'SWAMP_DRAGON_REDIS_DB', 0)
     return redis_db
+
+
+def get_redis_password():
+    global redis_password
+    if not redis_password:
+        redis_password = getattr(settings, 'SWAMP_DRAGON_REDIS_PASSWORD', None)
+    return redis_password

--- a/swampdragon/pubsub_providers/redis_sub_provider.py
+++ b/swampdragon/pubsub_providers/redis_sub_provider.py
@@ -2,7 +2,7 @@ import json
 import tornadoredis.pubsub
 import tornadoredis
 from .base_provider import BaseProvider
-from .redis_settings import get_redis_host, get_redis_port, get_redis_db
+from .redis_settings import get_redis_host, get_redis_port, get_redis_db, get_redis_password
 
 
 class RedisSubProvider(BaseProvider):
@@ -10,6 +10,7 @@ class RedisSubProvider(BaseProvider):
         self._subscriber = tornadoredis.pubsub.SockJSSubscriber(tornadoredis.Client(
             host=get_redis_host(),
             port=get_redis_port(),
+            password=get_redis_password(),
             selected_db=get_redis_db()
         ))
 


### PR DESCRIPTION
Adds the ability to specify a [optional] Redis DB password to Django settings.

This is a must for the vast majority of deployment setups - default Redis configurations for services like Heroku (Redis Cloud, HerokuRedis, or RedisToGo) all have databases that require passwords. The same is true for OpenShift, AWS, etc. Note that redis.StrictRedis already has a password parameter that can be passed in (which defaults to None).