### PR TITLE
remove get_all_related_many_to_many_objects()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     include_package_data=True,
     entry_points={'console_scripts': ['dragon-admin = swampdragon.core:run', ]},
     install_requires=[
-        "Django >= 1.6, < 2.0",
+        "Django >= 1.6, < 1.9",
         "Tornado >= 3.2.2",
         "sockjs-tornado >= 1.0.0",
         "tornado-redis >= 2.4.18",

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     include_package_data=True,
     entry_points={'console_scripts': ['dragon-admin = swampdragon.core:run', ]},
     install_requires=[
-        "Django >= 1.6, < 1.9",
+        "Django >= 1.6, < 2.0",
         "Tornado >= 3.2.2",
         "sockjs-tornado >= 1.0.0",
         "tornado-redis >= 2.4.18",

--- a/swampdragon/serializers/model_serializer.py
+++ b/swampdragon/serializers/model_serializer.py
@@ -67,9 +67,9 @@ class ModelSerializer(Serializer):
         return [f for f in self.opts.update_fields if f not in self.base_fields and f not in self.m2m_fields]
 
     def _get_m2m_fields(self):
-        try:
+        if hasattr(self.opts.model._meta,'get_all_related_many_to_many_objects'):
             related_m2m = [f.get_accessor_name() for f in self.opts.model._meta.get_all_related_many_to_many_objects()]
-        except AttributeError:
+        else:
             related_m2m = [f.get_accessor_name() for f in [_f for _f in self.opts.model._meta.get_fields(include_hidden=True) if _f.many_to_many and _f.auto_created]]
         m2m_fields = [f.name for f in self.opts.model._meta.local_many_to_many]
         m2m = m2m_fields + related_m2m

--- a/swampdragon/serializers/model_serializer.py
+++ b/swampdragon/serializers/model_serializer.py
@@ -67,7 +67,10 @@ class ModelSerializer(Serializer):
         return [f for f in self.opts.update_fields if f not in self.base_fields and f not in self.m2m_fields]
 
     def _get_m2m_fields(self):
-        related_m2m = [f.get_accessor_name() for f in [_f for _f in self.opts.model._meta.get_fields(include_hidden=True) if _f.many_to_many and _f.auto_created]]
+        try:
+            related_m2m = [f.get_accessor_name() for f in self.opts.model._meta.get_all_related_many_to_many_objects()]
+        except AttributeError:
+            related_m2m = [f.get_accessor_name() for f in [_f for _f in self.opts.model._meta.get_fields(include_hidden=True) if _f.many_to_many and _f.auto_created]]
         m2m_fields = [f.name for f in self.opts.model._meta.local_many_to_many]
         m2m = m2m_fields + related_m2m
         return [f for f in self.opts.update_fields if f in m2m]

--- a/swampdragon/serializers/model_serializer.py
+++ b/swampdragon/serializers/model_serializer.py
@@ -67,7 +67,7 @@ class ModelSerializer(Serializer):
         return [f for f in self.opts.update_fields if f not in self.base_fields and f not in self.m2m_fields]
 
     def _get_m2m_fields(self):
-        related_m2m = [f.get_accessor_name() for f in self.opts.model._meta.get_all_related_many_to_many_objects()]
+        related_m2m = [f.get_accessor_name() for f in [_f for _f in self.opts.model._meta.get_fields(include_hidden=True) if _f.many_to_many and _f.auto_created]]
         m2m_fields = [f.name for f in self.opts.model._meta.local_many_to_many]
         m2m = m2m_fields + related_m2m
         return [f for f in self.opts.update_fields if f in m2m]

--- a/swampdragon/serializers/model_serializer.py
+++ b/swampdragon/serializers/model_serializer.py
@@ -67,9 +67,9 @@ class ModelSerializer(Serializer):
         return [f for f in self.opts.update_fields if f not in self.base_fields and f not in self.m2m_fields]
 
     def _get_m2m_fields(self):
-        if hasattr(self.opts.model._meta,get_all_related_many_to_many_objects)
+        try:
             related_m2m = [f.get_accessor_name() for f in self.opts.model._meta.get_all_related_many_to_many_objects()]
-        else:
+        except AttributeError:
             related_m2m = [f.get_accessor_name() for f in [_f for _f in self.opts.model._meta.get_fields(include_hidden=True) if _f.many_to_many and _f.auto_created]]
         m2m_fields = [f.name for f in self.opts.model._meta.local_many_to_many]
         m2m = m2m_fields + related_m2m

--- a/swampdragon/serializers/model_serializer.py
+++ b/swampdragon/serializers/model_serializer.py
@@ -67,9 +67,9 @@ class ModelSerializer(Serializer):
         return [f for f in self.opts.update_fields if f not in self.base_fields and f not in self.m2m_fields]
 
     def _get_m2m_fields(self):
-        try:
+        if hasattr(self.opts.model._meta,get_all_related_many_to_many_objects)
             related_m2m = [f.get_accessor_name() for f in self.opts.model._meta.get_all_related_many_to_many_objects()]
-        except AttributeError:
+        else:
             related_m2m = [f.get_accessor_name() for f in [_f for _f in self.opts.model._meta.get_fields(include_hidden=True) if _f.many_to_many and _f.auto_created]]
         m2m_fields = [f.name for f in self.opts.model._meta.local_many_to_many]
         m2m = m2m_fields + related_m2m


### PR DESCRIPTION
remove get_all_related_many_to_many_objects() which has been deprecated in django 1.8
