### PR TITLE
Fixing selfpub_example so that StaffSerializer works correctly

### DIFF
--- a/docs/serializers/index.md
+++ b/docs/serializers/index.md
@@ -65,7 +65,7 @@ If a property containing a serializer with the same name as the function (minus 
 To include related data in a serializer, the related model need a serializer of it own.
 
     class FooSerializer(ModelSerializer):
-        baz_set = 'app.BazSerializer'
+        baz_set = 'BazSerializer'
     
         class Meta:
             model = 'app.FooModel'
@@ -88,13 +88,6 @@ Full path to serializer
     
     class Serializer(ModelSerializer):
         related = OtherSerializer
-
-
-\['app'\].\['serializer'\]. 
-
-
-    class Serializer(ModelSerializer):
-        related = 'app.OtherSerializer'
 
 
 \['serializer'\] (if the serializer is in the same .py file)

--- a/selfpub_example/selfpub_example/app/serializers.py
+++ b/selfpub_example/selfpub_example/app/serializers.py
@@ -8,22 +8,22 @@ class CompanyOwnerSerializer(ModelSerializer):
 
 class CompanySerializer(ModelSerializer):
     companyowner = CompanyOwnerSerializer
-    staff = 'app.StaffSerializer'
+    staff = 'StaffSerializer'
 
     class Meta:
         model = 'app.Company'
         publish_fields = ('name', 'staff', 'companyowner')
-        update_fields = ('name', )
-
-
-class StaffSerializer(ModelSerializer):
-    documents = 'app.DocumentSerializer'
-
-    class Meta:
-        model = 'app.Staff'
-        publish_fields = ('name', 'documents', 'company')
+        update_fields = ('name',)
 
 
 class DocumentSerializer(ModelSerializer):
     class Meta:
         model = 'app.Document'
+
+
+class StaffSerializer(ModelSerializer):
+    documents = 'DocumentSerializer'
+
+    class Meta:
+        model = 'app.Staff'
+        publish_fields = ('name', 'documents', 'company')


### PR DESCRIPTION
If you specifiy an app prefix for a serializer in the same app, it will not work (it tries to load from app.app.serializer).  As a result, I updated the selfpub_example to remove the app. prefix, and it now works correctly. I also removed the misleading documentation section.