### PR TITLE
Support for Redis-Sentinel

### DIFF
--- a/swampdragon/pubsub_providers/redis_publisher.py
+++ b/swampdragon/pubsub_providers/redis_publisher.py
@@ -1,5 +1,7 @@
 import json
 import redis
+from redis.sentinel import Sentinel
+from swampdragon.pubsub_providers.redis_settings import is_redis_sentinel, get_redis_sentinel_master
 from .redis_settings import get_redis_host, get_redis_port, get_redis_db, get_redis_password
 
 _redis_cli = None
@@ -7,13 +9,18 @@ _redis_cli = None
 
 def get_redis_cli():
     global _redis_cli
-    if not _redis_cli:
+    if not _redis_cli and is_redis_sentinel():
+        sentinel = Sentinel([(get_redis_host(), get_redis_port())], socket_timeout=0.1)
+        _redis_cli = sentinel.master_for(get_redis_sentinel_master(), socket_timeout=0.1)
+
+    elif not _redis_cli:
         _redis_cli = redis.StrictRedis(
             host=get_redis_host(),
             port=get_redis_port(),
             db=get_redis_db(),
             password=get_redis_password()
         )
+
     return _redis_cli
 
 

--- a/swampdragon/pubsub_providers/redis_settings.py
+++ b/swampdragon/pubsub_providers/redis_settings.py
@@ -4,7 +4,8 @@ redis_host = None
 redis_port = None
 redis_db = None
 redis_password = None
-
+redis_sentinel = None
+redis_sentinel_master = False
 
 def get_redis_host():
     global redis_host

--- a/swampdragon/pubsub_providers/redis_settings.py
+++ b/swampdragon/pubsub_providers/redis_settings.py
@@ -32,3 +32,16 @@ def get_redis_password():
     if not redis_password:
         redis_password = getattr(settings, 'SWAMP_DRAGON_REDIS_PASSWORD', None)
     return redis_password
+
+
+def is_redis_sentinel():
+    global redis_sentinel
+    if not redis_sentinel:
+        redis_sentinel = getattr(settings, 'SWAMP_DRAGON_USE_REDIS_SENTINEL', False)
+    return redis_sentinel
+
+def get_redis_sentinel_master():
+    global redis_sentinel_master
+    if not redis_sentinel_master:
+        redis_sentinel_master = getattr(settings, 'SWAMP_DRAGON_REDIS_SENTINEL_MASTER', 'mymaster') # default master name
+    return redis_sentinel_master

--- a/swampdragon/pubsub_providers/redis_settings.py
+++ b/swampdragon/pubsub_providers/redis_settings.py
@@ -37,7 +37,7 @@ def get_redis_password():
 def is_redis_sentinel():
     global redis_sentinel
     if not redis_sentinel:
-        redis_sentinel = getattr(settings, 'SWAMP_DRAGON_USE_REDIS_SENTINEL', False)
+        redis_sentinel = getattr(settings, 'SWAMP_DRAGON_REDIS_SENTINEL_MODE', False)
     return redis_sentinel
 
 def get_redis_sentinel_master():


### PR DESCRIPTION
This PR allows you to use Redis-Sentinel nodes with swampdragon.
The default connection functionality is already being served by redis-py.

New parameters are:
SWAMP_DRAGON_REDIS_SENTINEL_MODE = <ACTIVE:BOOL>
SWAMP_DRAGON_REDIS_SENTINEL_MASTER = <NAME OF REDIS MASTER:STRING>

Best,
Patrick