### PR TITLE
 returned html now in recommended form

### DIFF
--- a/swampdragon/templatetags/swampdragon_tags.py
+++ b/swampdragon/templatetags/swampdragon_tags.py
@@ -1,6 +1,7 @@
 from django import template
 from django.conf import settings
 from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 
 register = template.Library()
 
@@ -10,4 +11,5 @@ def swampdragon_settings():
     root_url = getattr(settings, 'DRAGON_URL') or 'http://localhost:9999/'
     if not root_url.endswith('/'):
         root_url += '/'
-    return mark_safe('<script type="text/javascript" src="{}settings.js"></script>'.format(root_url))
+    return format_html('<script type="text/javascript" src="{}settings.js"></script>',
+                       mark_safe(root_url))


### PR DESCRIPTION
Django says this form is more robust:

https://docs.djangoproject.com/en/1.9/ref/utils/?highlight=safestring#django.utils.html.format_html

-Dave