### PR TITLE
Fixing install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     include_package_data=True,
     entry_points={'console_scripts': ['dragon-admin = swampdragon.core:run', ]},
     install_requires=[
-        "Django >= 1.6, < 1.10",
+        "Django>=1.6,<1.10",
         "Tornado >= 3.2.2",
         "sockjs-tornado >= 1.0.0",
         "tornado-redis >= 2.4.18",


### PR DESCRIPTION
for multi versioning it seems that whitespaces are not allowed.

This is the same problem as pull request #198 fixed, but that fix was probably accidentally removed because of a later merge.