### PR TITLE
Unix Socket Support for Swampdragon

### DIFF
--- a/swampdragon/pubsub_providers/redis_publisher.py
+++ b/swampdragon/pubsub_providers/redis_publisher.py
@@ -1,13 +1,21 @@
 import json
 import redis
-from .redis_settings import get_redis_host, get_redis_port, get_redis_db, get_redis_password
+from .redis_settings import get_redis_host, get_redis_port, get_redis_db, get_redis_password, get_redis_socket
 
 _redis_cli = None
 
 
 def get_redis_cli():
     global _redis_cli
-    if not _redis_cli:
+    socket = get_redis_socket()
+    if not _redis_cli and socket:
+        _redis_cli = redis.StrictRedis(
+            unix_socket_path=socket,
+            port=get_redis_port(),
+            db=get_redis_db(),
+            password=get_redis_password()
+        )
+    elif not _redis_cli and not socket:
         _redis_cli = redis.StrictRedis(
             host=get_redis_host(),
             port=get_redis_port(),

--- a/swampdragon/pubsub_providers/redis_settings.py
+++ b/swampdragon/pubsub_providers/redis_settings.py
@@ -4,7 +4,7 @@ redis_host = None
 redis_port = None
 redis_db = None
 redis_password = None
-
+redis_socket = None
 
 def get_redis_host():
     global redis_host
@@ -32,3 +32,9 @@ def get_redis_password():
     if not redis_password:
         redis_password = getattr(settings, 'SWAMP_DRAGON_REDIS_PASSWORD', None)
     return redis_password
+
+def get_redis_socket():
+    global redis_socket
+    if not redis_socket:
+        redis_socket = getattr(settings, 'SWAMP_DRAGON_REDIS_SOCKET', None)
+    return redis_socket

--- a/swampdragon/pubsub_providers/redis_sub_provider.py
+++ b/swampdragon/pubsub_providers/redis_sub_provider.py
@@ -2,17 +2,25 @@ import json
 import tornadoredis.pubsub
 import tornadoredis
 from .base_provider import BaseProvider
-from .redis_settings import get_redis_host, get_redis_port, get_redis_db, get_redis_password
-
+from .redis_settings import get_redis_host, get_redis_port, get_redis_db, get_redis_password, get_redis_socket
 
 class RedisSubProvider(BaseProvider):
     def __init__(self):
-        self._subscriber = tornadoredis.pubsub.SockJSSubscriber(tornadoredis.Client(
-            host=get_redis_host(),
-            port=get_redis_port(),
-            password=get_redis_password(),
-            selected_db=get_redis_db()
-        ))
+        socket = get_redis_socket()
+        if socket is not None:
+            self._subscriber = tornadoredis.pubsub.SockJSSubscriber(tornadoredis.Client(
+                unix_socket_path=socket,
+                port=get_redis_port(),
+                password=get_redis_password(),
+                selected_db=get_redis_db()
+            ))
+        else:
+            self._subscriber = tornadoredis.pubsub.SockJSSubscriber(tornadoredis.Client(
+                host=get_redis_host(),
+                port=get_redis_port(),
+                password=get_redis_password(),
+                selected_db=get_redis_db()
+            ))
 
     def close(self, broadcaster):
         for channel in self._subscriber.subscribers:


### PR DESCRIPTION
Hi all! 
As I am using an uberspace (www.uberspace.de) to deploy my swampdragon app, I was forced to use  a redis socket over binding my server's IP to a specific port.
In consequence, the current implementation at that time wouldn't work for me.
What I did was to introduce a new setting called `SWAMP_DRAGON_REDIS_SOCKET` and implement checks in the respective files dealing with tornadoredis and redis-cli instances to use swampdragon in my configuration.
